### PR TITLE
Link to User APIs fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## APIs
 
 - [Login](/login)
-- [User](/users)
+- [User](/user)


### PR DESCRIPTION
The folder name seems to have changed to **user** from **users** thereby breaking the link, which this PR fixes! Small but important fix 😛