### PR TITLE
Contract for sending phone and email only for users/self based on value of query

### DIFF
--- a/users/README.md
+++ b/users/README.md
@@ -24,6 +24,8 @@
   'tokens': {}
 }
 ```
+**Note:**: Only the GET `users/self` route will return `phone` and `email` if `private` query is passed as true. This way we are not exposing users' phone numbers and email addresses to everyone. Users can only see their own phone number and email address.
+
 
 ## **Requests**
 
@@ -73,6 +75,8 @@ Returns the details of logged in user.
 
 - **Params**  
   None
+- **Query**
+  private=[boolean]    
 - **Body**  
   None
 - **Headers**  
@@ -82,6 +86,7 @@ Returns the details of logged in user.
 - **Success Response:**
   - **Code:** 200
     - **Content:** `{ <user_object> }`
+    > **Note**: The user object will include `phone` and `email` only when the query `private` is passed as `true` for this route. No other route will return `phone` and `email`.
 - **Error Response:**
   - **Code:** 401
     - **Content:** `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`


### PR DESCRIPTION
Since the signup form is now taking phone number and email address, we should not send them as response for every API. No user should be able to see other user's phone number and email address.