### PR TITLE
feat: updated description for GET/users query-params

### DIFF
--- a/users/README.md
+++ b/users/README.md
@@ -47,7 +47,9 @@ Returns all users in the system.
 - **Params**  
   None
 - **Query**  
-  size=[integer], page=[integer]
+  Optional: `size=[integer]` (`size` is number of users requested per page, value ranges in between 1-100, and default value is 100) 
+  <br>
+  Optional: `page=[integer]` (`page` can either be 0 or positive-number, and default value is 0)
 - **Body**  
   None
 - **Headers**  


### PR DESCRIPTION
## Metalinks
[Issue: Add a max size in the /users query param size](https://github.com/Real-Dev-Squad/website-backend/issues/842)
[PR: Max size for query params](https://github.com/Real-Dev-Squad/website-backend/pull/873)

## Before The Change
-  `GET/users` request query params `size` and `page`, 
were just stated with types without optional label.

## After The Change
- `GET/users` request query params `size` and `page` 
description is updated, with label optional.