### PR TITLE
API Contract to retrieve individual Progress Document and trackedProgresses Collection

### DIFF
--- a/progress/README.md
+++ b/progress/README.md
@@ -2,11 +2,12 @@
 
 ## Requests
 
-|                     Route                     |                                          Description                                          |
-| :-------------------------------------------: | :-------------------------------------------------------------------------------------------: |
-|     [POST /progresses](#post-progresses)      |                                 Creates a new progress entry.                                 |
-|      [GET /progresses](#get-progresses)       |                 Retrieves progress entries based on the provided parameters.                  |
-| [GET /progresses/range](#get-progressesrange) | Retrieves the progress records for a particular user or task within the specified date range. |
+|                     Route                     |                                           Description                                           |
+| :-------------------------------------------: | :---------------------------------------------------------------------------------------------: |
+|     [POST /progresses](#post-progresses)      |                                  Creates a new progress entry.                                  |
+|      [GET /progresses](#get-progresses)       |                  Retrieves progress entries based on the provided parameters.                   |
+| [GET /progresses/range](#get-progressesrange) |  Retrieves the progress records for a particular user or task within the specified date range.  |
+| [GET /progresses/:type/:typeId/date/:date](#get-progressestypetypeiddatedate)  | Retrieves the progress documents based on a specific user ID or task ID for the specified date. |
 
 ## POST /progresses
 
@@ -85,7 +86,7 @@
     - **Content:**
       ```json
       {
-        "message": "Internal Server Error"
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
       }
       ```
 
@@ -222,7 +223,7 @@ Retrieves progress entries based on the provided parameters.
     - **Content:**
       ```json
       {
-        "message": "Internal Server Error"
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
       }
       ```
 
@@ -321,7 +322,7 @@ Retrieves progress entries based on the provided parameters.
   Status: 500 Internal Server Error
   ```json
   {
-    "message": "Internal Server Error."
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
   }
   ```
 
@@ -392,7 +393,7 @@ Retrieves the progress records for a particular user or task within the specifie
     - **Content:**
       ```json
       {
-        "message": "Internal Server Error"
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
       }
       ```
 
@@ -448,6 +449,125 @@ Retrieves the progress records for a particular user or task within the specifie
   Status: 500 Internal Server Error
   ```json
   {
-    "message": "Internal Server Error."
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+  }
+  ```
+
+## GET /progresses/:type/:typeId/date/:date
+
+Retrieves the progress documents based on a specific user ID or task ID for the specified date.
+
+- **Params**
+
+  - type : Specifies the type of progress i.e. "task" or "user"
+  - typeId : Specifies the ID of the type i.e. "taskId" or "userId"
+  - date : Specifies the date of the progress record in ISO 8601 format i.e YYYY-MM-DD (e.g. "2023-05-02")
+
+- **Query**
+  None
+- **Body**  
+  None
+- **Headers**  
+  None
+- **Cookie**  
+  None
+- **Success Response:**
+
+  - **Code:** 200
+
+    - **Content:**
+
+    ```json
+    {
+      "message": "string",
+      "data": {
+        "id": "string",
+        "createdAt": "unixTimeStamp",
+        "blockers": "string",
+        "completed": "string",
+        "planned": "string",
+        "type": "string",
+        "userId": "string",
+        "date": "unixTimeStamp"
+      }
+    }
+    ```
+
+- **Error Response:**
+
+  - **Code:** 400
+
+    - **Content:**
+      ```json
+      {
+        "message": "Bad Request"
+      }
+      ```
+
+  - **Code:** 404
+    - **Content:**
+      ```json
+      {
+        "message": "User / Task with id <:id> does not exist."
+      },
+      {
+        "message": "No progress records found."
+      }
+      ```
+  - **Code:** 500
+    - **Content:**
+      ```json
+      {
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+      }
+      ```
+
+- **Example:**
+  GET /progresses/user/SooJK37gzjIZfFNH0tlL/date/2023-05-02
+  Status: 200 OK
+  Note: The date passe in the query params is of ISO 8601 format i.e YYYY-MM-DD
+  ```json
+  {
+    "message": "Progress document retrieved successfully.",
+    "data": {
+      "id": "en7nlNnpfqoqodcmtMeZ",
+      "createdAt": 1683649828022,
+      "blockers": "None",
+      "completed": "Monitoring for issues and performance",
+      "planned": "Plan for future enhancements",
+      "type": "user",
+      "userId": "SooJK37gzjIZfFNH0tlL",
+      "date": 1682985600000
+    }
+  }
+  ```
+  GET /progresses/user/SooJK37gzjIZfFNH0tlL/date/2023-05-33
+  Status: 400 Bad Request
+  ```json
+  {
+    "statusCode": 400,
+    "error": "Bad Request",
+    "message": "date must be in ISO 8601 date format"
+  }
+  ```
+  GET /progresses/user/ZHjfz7NSIKFo3t0ogl1LJ/date/2023-05-33
+  Status: 404 Not Found
+  ```json
+  {
+    "message": "User with id invalidUserId does not exist."
+  }
+  ```
+  GET /progresses/user/SooJK37gzjIZfFNH0tlL/date/2023-05-02
+  Status: 404 Not Found
+  ```json
+  {
+    "message": "No progress records found."
+  }
+  ```
+  GET /progresses/user/SooJK37gzjIZfFNH0tlL/date/2023-05-02
+  Status: 500 Internal Server Error
+  ```json
+  {
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
   }
   ```

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -541,15 +541,6 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  For trackedProgresses document already created<br/>
-  Status 409 Conflict
-
-  ```json
-  {
-    "message": "User 4ERr8WrizICemnQnMF0U1511 is already being tracked."
-  }
-  ```
-
   For Internal Server Error on the server side<br/>
   Status 500 Internal Server Error
 

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -2,10 +2,11 @@
 
 ## Requests
 
-|                           Route                            |                            Description                             |
-| :--------------------------------------------------------: | :----------------------------------------------------------------: |
-|     [POST /trackedProgresses](#post-trackedprogresses)     |             Creates a new trackedProgresses document.              |
-| [GET /trackedProgresses](#get-trackedprogressestypetypeid) | Retrieves the trackedProgresses document based on path parameters. |
+|                                Route                                 |                            Description                             |
+| :------------------------------------------------------------------: | :----------------------------------------------------------------: |
+|          [POST /trackedProgresses](#post-trackedprogresses)          |             Creates a new trackedProgresses document.              |
+|      [GET /trackedProgresses](#get-trackedprogressestypetypeid)      | Retrieves the trackedProgresses document based on path parameters. |
+| [PATCH /trackedProgresses/:type/:id](#patch-trackedprogressestypeid) |            Updates an existing trackedProgresses entry.            |
 
 ## POST /trackedProgresses
 

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -94,7 +94,7 @@
     - **Content:**
       ```json
       {
-        "message": "User/task <:id> is already being tracked."
+        "message": "Resource is already being tracked."
       }
       ```
 
@@ -127,7 +127,7 @@
 
   ```json
   {
-    "message": "User trackedProgresses document created successfully.",
+    "message": "Document created successfully.",
     "data": {
       "id": "en7nlNnpfqoqodcmtMeZ",
       "type": "user",
@@ -159,7 +159,7 @@
 
   ```json
   {
-    "message": "User trackedProgresses document created successfully.",
+    "message": "Document created successfully.",
     "data": {
       "id": "en7nlNnpfqoqodcmtMeZ",
       "type": "task",
@@ -213,7 +213,7 @@
 
   ```json
   {
-    "message": "User 4ERr8WrizICemnQnMF0U1511 is already being tracked."
+    "message": "Resource is already being tracked."
   }
   ```
 
@@ -463,7 +463,7 @@ Retrieves the trackedProgress document based on the path parameters.
 
   ```json
   {
-    "message": "User trackedProgresses document updated successfully.",
+    "message": "Document updated successfully.",
     "data": {
       "id": "en7nlNnpfqoqodcmtMeZ",
       "type": "user",
@@ -492,7 +492,7 @@ Retrieves the trackedProgress document based on the path parameters.
 
   ```json
   {
-    "message": "User trackedProgresses document created successfully.",
+    "message": "Document created successfully.",
     "data": {
       "id": "en7nlNnpfqoqodcmtMeZ",
       "type": "task",

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -346,3 +346,201 @@ Retrieves the trackedProgress document based on the path parameters.
     "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
   }
   ```
+
+## PATCH /trackedProgresses/:type/:id
+
+    Updates an existing trackedProgresses entry.
+
+- **Params**
+
+  - type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
+  - id (required, string): The ID of the task or user associated with the trackedProgresses entry. i.e taskId or userId
+
+- **Query**<br/>
+  None
+- **Body**
+  - Attributes:
+    - currentlyTracked (optional,boolean): Whether the trackedProgresses entry is currently tracked
+    - frequency (optional, positive integer): The frequency of the trackedProgresses entry (only applicable for task).
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 200
+    - **Content:**
+      ```json
+      {
+        "message": "string",
+        "data": {
+          "id": "string",
+          "type": "string",
+          "userId": "string (for type user)",
+          "taskId": "string (for type task)",
+          "currentlyTracked": "boolean",
+          "frequency": "positive integer",
+          "createdAt": "ISO 8601 format Timestamp",
+          "updatedAt": "ISO 8601 format Timestamp"
+        }
+      }
+      ```
+- **Error Response:**
+
+  - **Code:** 400
+
+    - **Content:**
+      ```json
+      {
+        "message": "Bad Request."
+      }
+      ```
+
+  - **Code:** 401
+
+    - **Content:**
+      ```json
+      {
+        "message": "Unauthorized User."
+      }
+      ```
+
+  - **Code:** 403
+
+    - **Content:**
+      ```json
+      {
+        "message": "You do not have permission to access this resource."
+      }
+      ```
+
+  - **Code:** 404
+
+    - **Content:**
+      ```json
+      {
+        "message": "Resource not found."
+      }
+      ```
+
+  - **Code:** 500
+
+    - **Content:**
+      ```json
+      {
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+      }
+      ```
+
+- **Example for trackedProgresses POST request:**<br/>
+
+  PATCH /trackedProgresses/user/SooJK37gzjIZfFNH0tlL<br/>
+  Content-Type: application/json<br/>
+  Request-Body:<br/>
+
+  ```json
+  {
+    "currentlyTracked": false
+  }
+  ```
+
+  Response :<br/>
+  Status 200<br/>
+  Content-Type: application/json<br/>
+
+  ```json
+  {
+    "message": "User trackedProgresses document updated successfully.",
+    "data": {
+      "id": "en7nlNnpfqoqodcmtMeZ",
+      "type": "user",
+      "userId": "SooJK37gzjIZfFNH0tlL",
+      "frequency": 1,
+      "currentlyTracked": false,
+      "createdAt": "2023-05-16T14:35:00Z",
+      "updatedAt": "2023-05-16T14:35:00Z"
+    }
+  }
+  ```
+
+  POST /trackedProgresses/task/SooJK37gzjIZfFNH0tlL<br/>
+  Content-Type: application/json<br/>
+  Request-Body:<br/>
+
+  ```json
+  {
+    "currentlyTracked": false
+  }
+  ```
+
+  Response :<br/>
+  Status 201<br/>
+  Content-Type: application/json<br/>
+
+  ```json
+  {
+    "message": "User trackedProgresses document created successfully.",
+    "data": {
+      "id": "en7nlNnpfqoqodcmtMeZ",
+      "type": "task",
+      "taskId": "SooJK37gzjIZfFNH0tlL",
+      "frequency": 2,
+      "currentlyTracked": false,
+      "createdAt": "2023-05-16T14:35:00Z",
+      "updatedAt": "2023-05-16T14:35:00Z"
+    }
+  }
+  ```
+
+  For Bad Request from the client<br/>
+  Status 400 Bad Request
+
+  ```json
+  {
+    "message": "Bad Request."
+  }
+  ```
+
+  For Unauthenticated Request from the client<br/>
+  Status 401 Unauthorized
+
+  ```json
+  {
+    "message": "Unauthorized User."
+  }
+  ```
+
+  For someone who doesn't have superuser permissions<br/>
+  Status 403 Forbidden
+
+  ```json
+  {
+    "message": "You do not have permission to access this resource."
+  }
+  ```
+
+  For taskId that doesn't exist<br/>
+  Status 404 Not Found
+
+  ```json
+  {
+    "message": "Task 4ERr8WrizICemnQnMF0U1511 does not exist."
+  }
+  ```
+
+  For trackedProgresses document already created<br/>
+  Status 409 Conflict
+
+  ```json
+  {
+    "message": "User 4ERr8WrizICemnQnMF0U1511 is already being tracked."
+  }
+  ```
+
+  For Internal Server Error on the server side<br/>
+  Status 500 Internal Server Error
+
+  ```json
+  {
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+  }
+  ```

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -358,15 +358,21 @@ Retrieves the trackedProgress document based on the path parameters.
 
 - **Query**<br/>
   None
+
 - **Body**
+
   - Attributes:
     - currentlyTracked (optional,boolean): Whether the trackedProgresses entry is currently tracked
     - frequency (optional, positive integer): The frequency of the trackedProgresses entry (only applicable for task).
+
 - **Headers**  
   Content-Type: application/json
+
 - **Cookie**  
   rds-session: `<JWT>`
+
 - **Success Response:**
+
   - **Code:** 200
     - **Content:**
       ```json
@@ -384,6 +390,7 @@ Retrieves the trackedProgress document based on the path parameters.
         }
       }
       ```
+
 - **Error Response:**
 
   - **Code:** 400

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -2,12 +2,10 @@
 
 ## Requests
 
-|                                     Route                                     |                                           Description                                           |
-| :---------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
-|                     [POST /progresses](#post-progresses)                      |                                  Creates a new progress entry.                                  |
-|                      [GET /progresses](#get-progresses)                       |                  Retrieves progress entries based on the provided parameters.                   |
-|                 [GET /progresses/range](#get-progressesrange)                 |  Retrieves the progress records for a particular user or task within the specified date range.  |
-| [GET /progresses/:type/:typeId/date/:date](#get-progressestypetypeiddatedate) | Retrieves the progress documents based on a specific user ID or task ID for the specified date. |
+|                           Route                            |                            Description                             |
+| :--------------------------------------------------------: | :----------------------------------------------------------------: |
+|     [POST /trackedProgresses](#post-trackedprogresses)     |             Creates a new trackedProgresses document.              |
+| [GET /trackedProgresses](#get-trackedprogressestypetypeid) | Retrieves the trackedProgresses document based on path parameters. |
 
 ## POST /trackedProgresses
 

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -13,19 +13,25 @@
 
 - **Params**  
   None
+
 - **Query**
   None
-- **Body**  
-  Attributes:
-  -type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
-  -taskId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type task).
-  -userId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type user).
-  -currentlyTracked (required, boolean): Whether the trackedProgresses entry is currently tracked
-  -frequency (optional, positive integer): The frequency of the trackedProgresses entry (default is 1 if not specified for task, for user its always 1).
+
+- **Body**
+
+  - Attributes:
+    - type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
+    - taskId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type task).
+    - userId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type user).
+    - currentlyTracked (required, boolean): Whether the trackedProgresses entry is currently tracked
+    - frequency (optional, positive integer): The frequency of the trackedProgresses entry (default is 1 if not specified for task, for user its always 1).
+
 - **Headers**  
   Content-Type: application/json
+
 - **Cookie**  
   rds-session: `<JWT>`
+
 - **Success Response:**
   - **Code:** 201
     - **Content:**

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -1,0 +1,221 @@
+# API Contracts for trackedProgresses Collection
+
+## Requests
+
+|                                     Route                                     |                                           Description                                           |
+| :---------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------: |
+|                     [POST /progresses](#post-progresses)                      |                                  Creates a new progress entry.                                  |
+|                      [GET /progresses](#get-progresses)                       |                  Retrieves progress entries based on the provided parameters.                   |
+|                 [GET /progresses/range](#get-progressesrange)                 |  Retrieves the progress records for a particular user or task within the specified date range.  |
+| [GET /progresses/:type/:typeId/date/:date](#get-progressestypetypeiddatedate) | Retrieves the progress documents based on a specific user ID or task ID for the specified date. |
+
+## POST /trackedProgresses
+
+    Creates a new trackedProgresses entry.
+
+- **Params**  
+  None
+- **Query**
+  None
+- **Body**  
+  Attributes:
+  -type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
+  -taskId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type task).
+  -userId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type user).
+  -currentlyTracked (required, boolean): Whether the trackedProgresses entry is currently tracked
+  -frequency (optional, positive integer): The frequency of the trackedProgresses entry (default is 1 if not specified for task, for user its always 1).
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 201
+    - **Content:**
+      ```json
+      {
+        "message": "string",
+        "data": {
+          "id": "string",
+          "type": "string",
+          "userId": "string (for type user)",
+          "taskId": "string (for type task)",
+          "currentlyTracked": "boolean",
+          "frequency": "positive integer",
+          "createdAt": "ISO 8601 format Timestamp",
+          "updatedAt": "ISO 8601 format Timestamp"
+        }
+      }
+      ```
+- **Error Response:**
+
+  - **Code:** 400
+
+    - **Content:**
+      ```json
+      {
+        "message": "Bad Request."
+      }
+      ```
+
+  - **Code:** 401
+
+    - **Content:**
+      ```json
+      {
+        "message": "Unauthorized User."
+      }
+      ```
+
+  - **Code:** 403
+
+    - **Content:**
+      ```json
+      {
+        "message": "You do not have permission to access this resource."
+      }
+      ```
+
+  - **Code:** 404
+
+    - **Content:**
+      ```json
+      {
+        "message": "User/Task id <:id> does not exist."
+      }
+      ```
+
+  - **Code:** 409
+
+    - **Content:**
+      ```json
+      {
+        "message": "User/task <:id> is already being tracked."
+      }
+      ```
+
+  - **Code:** 500
+
+    - **Content:**
+      ```json
+      {
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+      }
+      ```
+
+- **Example for trackedProgresses POST request:**<br/>
+
+  POST /trackedProgresses</br>
+  Content-Type: application/json</br>
+  Request-Body:</br>
+
+  ```json
+  {
+    "type": "user",
+    "userId": "SooJK37gzjIZfFNH0tlL",
+    "currentlyTracked": true
+  }
+  ```
+
+  Response :</br>
+  Status 201</br>
+  Content-Type: application/json</br>
+
+  ```json
+  {
+    "message": "User trackedProgresses document created successfully.",
+    "data": {
+      "id": "en7nlNnpfqoqodcmtMeZ",
+      "type": "user",
+      "userId": "SooJK37gzjIZfFNH0tlL",
+      "frequency": 1,
+      "currentlyTracked": true,
+      "createdAt": "2023-05-16T14:35:00Z",
+      "updatedAt": "2023-05-16T14:35:00Z"
+    }
+  }
+  ```
+  POST /trackedProgresses</br>
+  Content-Type: application/json</br>
+  Request-Body:</br>
+
+  ```json
+  {
+    "type": "task",
+    "taskId": "SooJK37gzjIZfFNH0tlL",
+    "currentlyTracked": true,
+    "frequency": 2
+  }
+  ```
+
+  Response :</br>
+  Status 201</br>
+  Content-Type: application/json</br>
+
+  ```json
+  {
+    "message": "User trackedProgresses document created successfully.",
+    "data": {
+      "id": "en7nlNnpfqoqodcmtMeZ",
+      "type": "task",
+      "taskId": "SooJK37gzjIZfFNH0tlL",
+      "frequency": 2,
+      "currentlyTracked": true,
+      "createdAt": "2023-05-16T14:35:00Z",
+      "updatedAt": "2023-05-16T14:35:00Z"
+    }
+  }
+  ```
+
+  For Bad Request from the client</br>
+  Status 400 Bad Request
+
+  ```json
+  {
+    "message": "Bad Request."
+  }
+  ```
+
+  For Unauthenticated Request from the client</br>
+  Status 401 Unauthorized
+
+  ```json
+  {
+    "message": "Unauthorized User."
+  }
+  ```
+
+  For someone who doesn't have superuser permissions</br>
+  Status 403 Forbidden
+
+  ```json
+  {
+    "message": "You do not have permission to access this resource."
+  }
+  ```
+
+  For taskId that doesn't exist</br>
+  Status 404 Not Found
+
+  ```json
+  {
+    "message": "Task 4ERr8WrizICemnQnMF0U1511 does not exist."
+  }
+  ```
+
+  For trackedProgresses document already created</br>
+  Status 409 Conflict
+
+  ```json
+  {
+    "message": "User 4ERr8WrizICemnQnMF0U1511 is already being tracked."
+  }
+  ```
+
+  For Internal Server Error on the server side</br>
+  Status 500 Internal Server Error
+
+  ```json
+  {
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+  }
+  ```

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -1,16 +1,16 @@
-# API Contracts for trackedProgresses Collection
+# API Contracts for tracked-progresses Collection
 
 ## Requests
 
-|                                Route                                 |                            Description                             |
-| :------------------------------------------------------------------: | :----------------------------------------------------------------: |
-|          [POST /trackedProgresses](#post-trackedprogresses)          |             Creates a new trackedProgresses document.              |
-|      [GET /trackedProgresses](#get-trackedprogressestypetypeid)      | Retrieves the trackedProgresses document based on path parameters. |
-| [PATCH /trackedProgresses/:type/:id](#patch-trackedprogressestypeid) |            Updates an existing trackedProgresses entry.            |
+|                                 Route                                  |                             Description                             |
+| :--------------------------------------------------------------------: | :-----------------------------------------------------------------: |
+|          [POST /tracked-progresses](#post-tracked-progresses)          |             Creates a new tracked-progresses document.              |
+|      [GET /tracked-progresses](#get-tracked-progressestypetypeid)      | Retrieves the tracked-progresses document based on path parameters. |
+| [PATCH /tracked-progresses/:type/:id](#patch-tracked-progressestypeid) |            Updates an existing tracked-progresses entry.            |
 
-## POST /trackedProgresses
+## POST /tracked-progresses
 
-    Creates a new trackedProgresses entry.
+    Creates a new tracked-progresses entry.
 
 - **Params**  
   None
@@ -21,11 +21,11 @@
 - **Body**
 
   - Attributes:
-    - type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
-    - taskId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type task).
-    - userId (optional, string): Task ID associated with the trackedProgresses entry (applicable for type user).
-    - currentlyTracked (required, boolean): Whether the trackedProgresses entry is currently tracked
-    - frequency (optional, positive integer): The frequency of the trackedProgresses entry (default is 1 if not specified for task, for user its always 1).
+    - type (required, string): Specifies the type of the tracked-progresses entry (e.g., "task", "user").
+    - taskId (optional, string): Task ID associated with the tracked-progresses entry (applicable for type task).
+    - userId (optional, string): Task ID associated with the tracked-progresses entry (applicable for type user).
+    - currentlyTracked (required, boolean): Whether the tracked-progresses entry is currently tracked
+    - frequency (optional, positive integer): The frequency of the tracked-progresses entry (default is 1 if not specified for task, for user its always 1).
 
 - **Headers**  
   Content-Type: application/json
@@ -107,9 +107,9 @@
       }
       ```
 
-- **Example for trackedProgresses POST request:**<br/>
+- **Example for tracked-progresses POST request:**<br/>
 
-  POST /trackedProgresses<br/>
+  POST /tracked-progresses<br/>
   Content-Type: application/json<br/>
   Request-Body:<br/>
 
@@ -140,7 +140,7 @@
   }
   ```
 
-  POST /trackedProgresses<br/>
+  POST /tracked-progresses<br/>
   Content-Type: application/json<br/>
   Request-Body:<br/>
 
@@ -208,7 +208,7 @@
   }
   ```
 
-  For trackedProgresses document already created<br/>
+  For tracked-progresses document already created<br/>
   Status 409 Conflict
 
   ```json
@@ -226,7 +226,7 @@
   }
   ```
 
-## GET /trackedProgresses/:type/:typeId
+## GET /tracked-progresses/:type/:typeId
 
 Retrieves the trackedProgress document based on the path parameters.
 
@@ -300,7 +300,7 @@ Retrieves the trackedProgress document based on the path parameters.
 
 - **Example:**
 
-  GET /trackedProgresses/user/SooJK37gzjIZfFNH0tlL<br/>
+  GET /tracked-progresses/user/SooJK37gzjIZfFNH0tlL<br/>
   Status: 200 OK
 
   ```json
@@ -318,7 +318,7 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  GET /trackedProgresses/event/hPz5hfWBd9oSwMljGk1s<br/>
+  GET /tracked-progresses/event/hPz5hfWBd9oSwMljGk1s<br/>
   Status: 400 Bad Request
 
   ```json
@@ -327,7 +327,7 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  GET /trackedProgresses/user/SooSk37gzjIZfFNH0tlL<br/>
+  GET /tracked-progresses/user/SooSk37gzjIZfFNH0tlL<br/>
   Status: 404 Not Found
 
   ```json
@@ -336,7 +336,7 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  GET /trackedProgresses/user/invalidUser<br/>
+  GET /tracked-progresses/user/invalidUser<br/>
   Status: 404 Not Found
 
   ```json
@@ -345,7 +345,7 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  GET /trackedProgresses/user/hPz5hfWBd9oSwMljGk1s<br/>
+  GET /tracked-progresses/user/hPz5hfWBd9oSwMljGk1s<br/>
   Status: 500 Internal Server Error
 
   ```json
@@ -354,14 +354,14 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-## PATCH /trackedProgresses/:type/:id
+## PATCH /tracked-progresses/:type/:id
 
-    Updates an existing trackedProgresses entry.
+    Updates an existing tracked-progresses entry.
 
 - **Params**
 
-  - type (required, string): Specifies the type of the trackedProgresses entry (e.g., "task", "user").
-  - id (required, string): The ID of the task or user associated with the trackedProgresses entry. i.e taskId or userId
+  - type (required, string): Specifies the type of the tracked-progresses entry (e.g., "task", "user").
+  - id (required, string): The ID of the task or user associated with the tracked-progresses entry. i.e taskId or userId
 
 - **Query**<br/>
   None
@@ -369,8 +369,8 @@ Retrieves the trackedProgress document based on the path parameters.
 - **Body**
 
   - Attributes:
-    - currentlyTracked (optional,boolean): Whether the trackedProgresses entry is currently tracked
-    - frequency (optional, positive integer): The frequency of the trackedProgresses entry (only applicable for task).
+    - currentlyTracked (optional,boolean): Whether the tracked-progresses entry is currently tracked
+    - frequency (optional, positive integer): The frequency of the tracked-progresses entry (only applicable for task).
 
 - **Headers**  
   Content-Type: application/json
@@ -445,9 +445,9 @@ Retrieves the trackedProgress document based on the path parameters.
       }
       ```
 
-- **Example for trackedProgresses POST request:**<br/>
+- **Example for tracked-progresses POST request:**<br/>
 
-  PATCH /trackedProgresses/user/SooJK37gzjIZfFNH0tlL<br/>
+  PATCH /tracked-progresses/user/SooJK37gzjIZfFNH0tlL<br/>
   Content-Type: application/json<br/>
   Request-Body:<br/>
 
@@ -476,7 +476,7 @@ Retrieves the trackedProgress document based on the path parameters.
   }
   ```
 
-  POST /trackedProgresses/task/SooJK37gzjIZfFNH0tlL<br/>
+  POST /tracked-progresses/task/SooJK37gzjIZfFNH0tlL<br/>
   Content-Type: application/json<br/>
   Request-Body:<br/>
 

--- a/trackedProgresses/README.md
+++ b/trackedProgresses/README.md
@@ -104,9 +104,9 @@
 
 - **Example for trackedProgresses POST request:**<br/>
 
-  POST /trackedProgresses</br>
-  Content-Type: application/json</br>
-  Request-Body:</br>
+  POST /trackedProgresses<br/>
+  Content-Type: application/json<br/>
+  Request-Body:<br/>
 
   ```json
   {
@@ -116,9 +116,9 @@
   }
   ```
 
-  Response :</br>
-  Status 201</br>
-  Content-Type: application/json</br>
+  Response :<br/>
+  Status 201<br/>
+  Content-Type: application/json<br/>
 
   ```json
   {
@@ -134,9 +134,10 @@
     }
   }
   ```
-  POST /trackedProgresses</br>
-  Content-Type: application/json</br>
-  Request-Body:</br>
+
+  POST /trackedProgresses<br/>
+  Content-Type: application/json<br/>
+  Request-Body:<br/>
 
   ```json
   {
@@ -147,9 +148,9 @@
   }
   ```
 
-  Response :</br>
-  Status 201</br>
-  Content-Type: application/json</br>
+  Response :<br/>
+  Status 201<br/>
+  Content-Type: application/json<br/>
 
   ```json
   {
@@ -166,7 +167,7 @@
   }
   ```
 
-  For Bad Request from the client</br>
+  For Bad Request from the client<br/>
   Status 400 Bad Request
 
   ```json
@@ -175,7 +176,7 @@
   }
   ```
 
-  For Unauthenticated Request from the client</br>
+  For Unauthenticated Request from the client<br/>
   Status 401 Unauthorized
 
   ```json
@@ -184,7 +185,7 @@
   }
   ```
 
-  For someone who doesn't have superuser permissions</br>
+  For someone who doesn't have superuser permissions<br/>
   Status 403 Forbidden
 
   ```json
@@ -193,7 +194,7 @@
   }
   ```
 
-  For taskId that doesn't exist</br>
+  For taskId that doesn't exist<br/>
   Status 404 Not Found
 
   ```json
@@ -202,7 +203,7 @@
   }
   ```
 
-  For trackedProgresses document already created</br>
+  For trackedProgresses document already created<br/>
   Status 409 Conflict
 
   ```json
@@ -211,8 +212,136 @@
   }
   ```
 
-  For Internal Server Error on the server side</br>
+  For Internal Server Error on the server side<br/>
   Status 500 Internal Server Error
+
+  ```json
+  {
+    "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+  }
+  ```
+
+## GET /trackedProgresses/:type/:typeId
+
+Retrieves the trackedProgress document based on the path parameters.
+
+- **Params**<br/>
+
+  - type: The type of the trackedProgress document (string)
+  - typeId: The Id of the type tracked (string)
+
+- **Query**<br/>
+  None
+
+- **Body**  
+  None
+
+- **Headers**  
+  None
+
+- **Cookie**  
+  None
+
+- **Success Response:**
+
+  - **Code:** 200
+
+    - **Content:**
+
+    ```json
+    {
+      "message": "string",
+      "data": {
+        "id": "string",
+        "type": "string",
+        "userId": "string",
+        "taskId": "string",
+        "currentlyTracked": "boolean",
+        "frequency": "positive integer",
+        "createdAt": "Timestamp ISO 8601 format",
+        "updatedAt": "Timestamp ISO 8601 format"
+      }
+    }
+    ```
+
+- **Error Response:**
+
+  - **Code:** 400
+
+    - **Content:**
+      ```json
+      {
+        "message": "Bad Request"
+      }
+      ```
+
+  - **Code:** 404
+    - **Content:**
+      ```json
+      {
+        "message": "User / Task with id <:id> does not exist."
+      },
+      {
+        "message": "No trackedProgress records found."
+      }
+      ```
+  - **Code:** 500
+    - **Content:**
+      ```json
+      {
+        "message": "The server has encountered an unexpected error. Please contact the administrator for more information."
+      }
+      ```
+
+- **Example:**
+
+  GET /trackedProgresses/user/SooJK37gzjIZfFNH0tlL<br/>
+  Status: 200 OK
+
+  ```json
+  {
+    "message": "trackedProgress document retrieved successfully.",
+    "data": {
+      "id": "eBe01VS3oYI2HJuWdRuG",
+      "type": "user",
+      "userId": "SooJK37gzjIZfFNH0tlL",
+      "frequency": 1,
+      "currentlyTracked": true,
+      "createdAt": "2023-05-16T14:35:00Z",
+      "updatedAt": "2023-05-16T14:35:00Z"
+    }
+  }
+  ```
+
+  GET /trackedProgresses/event/hPz5hfWBd9oSwMljGk1s<br/>
+  Status: 400 Bad Request
+
+  ```json
+  {
+    "message": "type can either be user or task"
+  }
+  ```
+
+  GET /trackedProgresses/user/SooSk37gzjIZfFNH0tlL<br/>
+  Status: 404 Not Found
+
+  ```json
+  {
+    "message": "No progress records found."
+  }
+  ```
+
+  GET /trackedProgresses/user/invalidUser<br/>
+  Status: 404 Not Found
+
+  ```json
+  {
+    "message": "User invalidUser does not exist."
+  }
+  ```
+
+  GET /trackedProgresses/user/hPz5hfWBd9oSwMljGk1s<br/>
+  Status: 500 Internal Server Error
 
   ```json
   {


### PR DESCRIPTION
This PR adds API contract documentation for the new endpoint `/progresses/:type/:typeId/date/:date`. The API contract provides clear and detailed information about how to retrieve progress documents based on a specific user ID or task ID and a specified date.

This PR also adds API contract documentation for the new endpoint `/trackedProgresses`.

The Parent ticket can be found [here](https://github.com/Real-Dev-Squad/website-backend/issues/1076)