### PR TITLE
Feat: GET /tasks API contract with filter query params

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,9 +73,7 @@ Returns all the tasks
   None
 - **Query**  
   - Optional: `dev=[boolean]` (`dev` is passed to get all tasks in the developer mode with features that are flagged)
-  - Optional: `status=[string]`
-    (`status` can either a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED])
-    (`status` is a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED] which represents the status of the task)
+  - Optional: `status=[string]` (`status` is a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED] which represents the status of the task)
 - **Body**  
   None
 - **Headers**  

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -72,7 +72,10 @@ Returns all the tasks
 - **Params**  
   None
 - **Query**  
-  None
+  - Optional: `dev=[boolean]` (`dev` is passed to get all tasks in the developer mode with features that are flagged)
+  - Optional: `status=[string]`
+    (`status` can either a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED])
+    (`status` is a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED] which represents the status of the task)
 - **Body**  
   None
 - **Headers**  


### PR DESCRIPTION
This PR is for updating the existing `GET /tasks` API contract with the query parameters for filtering tasks. [Issue for filter tasks](https://github.com/Real-Dev-Squad/todo-action-items/issues/161).