### PR TITLE
API contract for applicants

### DIFF
--- a/applicants/README.md
+++ b/applicants/README.md
@@ -35,9 +35,8 @@
 |                         Route                          |             Description              |
 | :----------------------------------------------------: | :----------------------------------: |
 |                [GET /applications](#get-applications)                |   Returns all the applications in the system   |
-|           [GET /applications/:userId](#get-applicationsuserid)            | Retruns application of a particular user |
 |  [POST /applications](#post-applications)   |    Add application of a user    |
-|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Updates application of a user   |
+|       [PATCH /applications/:applicationId](#patch-applicationsapplicationid)       |   Updates application of a user   |
 |        |
 
 ## **GET /applications/**
@@ -47,7 +46,7 @@ Return all the applications which are not accepted or rejected, this API will on
 - **Params**  
   None
 - **Query** 
-  None
+    - Optional: `userId=[string]`: if userId is provided it return application of one user, if the user is not super user then the userId passed here must be the userId of that user only otherwise it will give 403
 - **Body**  
   None
 - **Headers**  
@@ -57,10 +56,18 @@ Return all the applications which are not accepted or rejected, this API will on
 - **Success Response:**
   - **Code:** 200
     - **Content:**
+    The following response will be returned if userId is not provided in the query param 
     ```
       { 
-        message: 'applications returned successfully!',
-        applications: <application_object> 
+        message: 'applications returned successfully! || 'applications returned successfully'',
+        applications: [<application_object>, <application_object>]
+      }
+    ```
+    The following response will be returned if userId is provided in the query param 
+    ```
+      { 
+        message: 'applications returned successfully! || 'application returned successfully'',
+        application: <application_object>
       }
     ```
 - **Error Response:**
@@ -101,8 +108,7 @@ Adds an application for joining RDS, a user can only add one application, until 
     - **Content:**
     ```
       { 
-        message: 'application added successfully!',
-        application: <application_object> 
+        message: 'User application added.',
       }
     ```
 - **Error Response:**
@@ -135,67 +141,17 @@ Adds an application for joining RDS, a user can only add one application, until 
       ```
 
 
-## **GET /applications/:userId**
 
-Return the application of a particular user, the super can access the application of any user, but any other can only access their application
-
-- **Params**  
-  _Required:_ `userId=[string]`
-- **Query** 
-  None
-- **Body**
-  None
-- **Headers**  
-  Content-Type: application/json
-- **Cookie**  
-  rds-session: `<JWT>`
-- **Success Response:**
-  - **Code:** 200
-    - **Content:**
-    ```
-      { 
-        message: 'User application returned successfully!', 
-        application: <application_object> }
-    ```
-- **Error Response:**
-  - **Code:** 401
-    - **Content:**
-      ```
-        { 
-          statusCode: 401,
-          error: 'Unauthorized',
-          message: 'Unauthenticated User' 
-        }
-      ```
-  - **Code:** 404
-    - **Content:**
-      ```
-        { 
-          'statusCode': 404,
-          'error': 'Not Found',
-          'message': 'Application doesn't exist' 
-        }
-      ```
-  - **Code:** 500
-    - **Content:**
-      ```
-        { 
-          statusCode: 500,
-          error: 'Internal Server Error',
-          message: 'An internal server error occurred' 
-        }
-      ```
-
-## **PATCH /applications/:userId**
+## **PATCH /applications/:applicationId**
 
 This will update a particular application, this API will only be accessible to super_user
 
 - **Params**  
   _Required:_ `userId=[string]`
 - **Query** 
-  _optional:_ `generate_discord_link=[boolean]`
 - **Body**
-  None
+  _optional_: `reason=[string]`
+  _optional_: `status=[string]`
 - **Headers**  
   Content-Type: application/json
 - **Cookie**  

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -41,7 +41,7 @@
 
 ## **GET /applications/**
 
-Return all the applications which are not accepted or rejected, this API will only be accessible to super_user
+Return all the applications which are not accepted or rejected, this API will only be accessible to super_user or user who have filled the application if the userId passed in same as the userId of the user
 
 - **Params**  
   None
@@ -147,7 +147,7 @@ Adds an application for joining RDS, a user can only add one application, until 
 This will update a particular application, this API will only be accessible to super_user
 
 - **Params**  
-  _Required:_ `userId=[string]`
+  _Required:_ `applicationId=[string]`
 - **Query** 
 - **Body**
   _optional_: `reason=[string]`

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -57,14 +57,31 @@ Return all the applications which are not accepted or rejected, this API will on
 - **Success Response:**
   - **Code:** 200
     - **Content:**
-    `{ 'message': 'applications returned successfully!', 'applications': <application_object> }`
+    ```
+      { 
+        message: 'applications returned successfully!',
+        applications: <application_object> 
+      }
+    ```
 - **Error Response:**
   - **Code:** 401
     - **Content:**
-      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+      ```
+        { 
+          statusCode: 401,
+          error:'Unauthorized',
+          message: 'Unauthenticated User'
+        }
+      ```
   - **Code:** 500
     - **Content:**
-      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+      ```
+        { 
+          statusCode: 500,
+          error: 'Internal Server Error', 
+          message: 'An internal server error occurred' 
+        }
+      ```
 
 ## **POST /applications/**
 
@@ -82,17 +99,40 @@ Adds an application for joining RDS, a user can only add one application, until 
 - **Success Response:**
   - **Code:** 201
     - **Content:**
-    `{ 'message': 'application added successfully!', 'application': <application_object> }`
+    ```
+      { 
+        message: 'application added successfully!',
+        application: <application_object> 
+      }
+    ```
 - **Error Response:**
   - **Code:** 401
     - **Content:**
-      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+      ```
+        { 
+          statusCode: 401,
+          error: 'Unauthorized',
+          message: 'Unauthenticated User' 
+        }
+      ```
   - **Code:** 409
     - **Content:**
-      `{ 'statusCode': 409, 'error': 'Conflict', 'message': 'User application is already present' }`
+      ```
+        { 
+          statusCode: 409, 
+          error: 'Conflict',
+          message: 'Previous application is still under process' 
+        }
+      ```
   - **Code:** 500
     - **Content:**
-      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+      ```
+        { 
+          statusCode: 500,
+          error: 'Internal Server Error',
+          message: 'An internal server error occurred' 
+        }
+      ```
 
 
 ## **GET /applications/:userId**
@@ -112,17 +152,39 @@ Return the application of a particular user, the super can access the applicatio
 - **Success Response:**
   - **Code:** 200
     - **Content:**
-    `{ 'message': 'User application returned successfully!', 'application': <application_object> }`
+    ```
+      { 
+        message: 'User application returned successfully!', 
+        application: <application_object> }
+    ```
 - **Error Response:**
   - **Code:** 401
     - **Content:**
-      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+      ```
+        { 
+          statusCode: 401,
+          error: 'Unauthorized',
+          message: 'Unauthenticated User' 
+        }
+      ```
   - **Code:** 404
     - **Content:**
-      `{ 'statusCode': 404, 'error': 'Not Found', 'message': 'Application doesn't exist' }`
+      ```
+        { 
+          'statusCode': 404,
+          'error': 'Not Found',
+          'message': 'Application doesn't exist' 
+        }
+      ```
   - **Code:** 500
     - **Content:**
-      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+      ```
+        { 
+          statusCode: 500,
+          error: 'Internal Server Error',
+          message: 'An internal server error occurred' 
+        }
+      ```
 
 ## **PATCH /applications/:userId**
 
@@ -141,14 +203,35 @@ This will update a particular application, this API will only be accessible to s
 - **Success Response:**
   - **Code:** 201
     - **Content:**
-    `{ 'message': 'Application updated successfully!' }`
+    ```
+      { 
+        message: 'Application updated successfully!' 
+      }
+    ```
 - **Error Response:**
   - **Code:** 401
     - **Content:**
-      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+      ```
+        { 
+          statusCode: 401,
+          error: 'Unauthorized',
+          message: 'Unauthenticated User' 
+        }
+      ```
   - **Code:** 404
     - **Content:**
-      `{ 'statusCode': 404, 'error': 'Not Found', 'message': 'Application doesn't exist' }`
+      ```
+        {
+          statusCode: 404,
+          error: 'Not Found',
+          message: 'Application doesn't exist' 
+        }
+      ```
   - **Code:** 500
     - **Content:**
-      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+      ```
+        { 
+          statusCode': 500,
+          error: 'Internal Server Error',
+          message: 'An internal server error occurred' }
+      ```

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -26,7 +26,7 @@
   },
   foundFrom: string,
   status: string || null,
-  discordLink: string || null
+  reason: string || null
 }
 ```
 

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -34,13 +34,13 @@
 
 |                         Route                          |             Description              |
 | :----------------------------------------------------: | :----------------------------------: |
-|                [GET /applications](#get-applicants)                |   Returns all the applications in the system   |
-|           [GET /applications/:userId](#get-applicantsuserid)            | Retruns application of a particular user |
-|  [POST /applications](#post-applicants)   |    Add application of a user    |
-|       [PATCH /applications/:userId](#patch-applicantsuserid)       |   Updates application of a user   |
+|                [GET /applications](#get-applications)                |   Returns all the applications in the system   |
+|           [GET /applications/:userId](#get-applicationsuserid)            | Retruns application of a particular user |
+|  [POST /applications](#post-applications)   |    Add application of a user    |
+|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Updates application of a user   |
 |        |
 
-## **GET /applicants/**
+## **GET /applications/**
 
 Return all the applications which are not accepted or rejected, this API will only be accessible to super_user
 
@@ -66,7 +66,7 @@ Return all the applications which are not accepted or rejected, this API will on
     - **Content:**
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
-## **POST /applicants/**
+## **POST /applications/**
 
 Adds an application for joining RDS, a user can only add one application, until the previous application is either rejected or accepted by super_user
 
@@ -95,7 +95,7 @@ Adds an application for joining RDS, a user can only add one application, until 
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
 
-## **GET /applicants/:userId**
+## **GET /applications/:userId**
 
 Return the application of a particular user, the super can access the application of any user, but any other can only access their application
 
@@ -124,7 +124,7 @@ Return the application of a particular user, the super can access the applicatio
     - **Content:**
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
-## **PATCH /applicants/:userId**
+## **PATCH /applications/:userId**
 
 This will update a particular application, this API will only be accessible to super_user
 
@@ -139,7 +139,7 @@ This will update a particular application, this API will only be accessible to s
 - **Cookie**  
   rds-session: `<JWT>`
 - **Success Response:**
-  - **Code:** 204
+  - **Code:** 201
     - **Content:**
     `{ 'message': 'Application updated successfully!' }`
 - **Error Response:**

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -150,7 +150,7 @@ This will update a particular application, this API will only be accessible to s
   _Required:_ `applicationId=[string]`
 - **Query** 
 - **Body**
-  _optional_: `reason=[string]`
+  _optional_: `feedback=[string]`
   _optional_: `status=[string]`
 - **Headers**  
   Content-Type: application/json

--- a/applicants/README.md
+++ b/applicants/README.md
@@ -1,6 +1,6 @@
-# application
+# applicants
 
-## application object
+## applicants object
 
 ```{
   userId: string,
@@ -34,13 +34,13 @@
 
 |                         Route                          |             Description              |
 | :----------------------------------------------------: | :----------------------------------: |
-|                [GET /applications](#get-applications)                |   Returns all the applications in the system   |
-|           [GET /applications/:userId](#get-applicationsuserid)            | Retruns application of a particular user |
-|  [POST /applications](#post-applications)   |    Add application of a user    |
-|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Updates application of a user   |
+|                [GET /applications](#get-applicants)                |   Returns all the applications in the system   |
+|           [GET /applications/:userId](#get-applicantsuserid)            | Retruns application of a particular user |
+|  [POST /applications](#post-applicants)   |    Add application of a user    |
+|       [PATCH /applications/:userId](#patch-applicantsuserid)       |   Updates application of a user   |
 |        |
 
-## **GET /applications/**
+## **GET /applicants/**
 
 Return all the applications which are not accepted or rejected, this API will only be accessible to super_user
 
@@ -66,7 +66,7 @@ Return all the applications which are not accepted or rejected, this API will on
     - **Content:**
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
-## **POST /applications/**
+## **POST /applicants/**
 
 Adds an application for joining RDS, a user can only add one application, until the previous application is either rejected or accepted by super_user
 
@@ -95,7 +95,7 @@ Adds an application for joining RDS, a user can only add one application, until 
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
 
-## **GET /applications/:userId**
+## **GET /applicants/:userId**
 
 Return the application of a particular user, the super can access the application of any user, but any other can only access their application
 
@@ -124,7 +124,7 @@ Return the application of a particular user, the super can access the applicatio
     - **Content:**
       `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
 
-## **PATCH /applications/:userId**
+## **PATCH /applicants/:userId**
 
 This will update a particular application, this API will only be accessible to super_user
 

--- a/applications/README.md
+++ b/applications/README.md
@@ -25,7 +25,8 @@
     numberOfHours: string,
   },
   foundFrom: string,
-  status: string
+  status: string || null,
+  discordLink: string || null
 }
 ```
 
@@ -101,7 +102,7 @@ Return the application of a particular user, the super can access the applicatio
 - **Params**  
   _Required:_ `userId=[string]`
 - **Query** 
-  None
+  _optional:_ `generate_discord_link=[boolean]`
 - **Body**
   None
 - **Headers**  

--- a/applications/README.md
+++ b/applications/README.md
@@ -102,7 +102,7 @@ Return the application of a particular user, the super can access the applicatio
 - **Params**  
   _Required:_ `userId=[string]`
 - **Query** 
-  _optional:_ `generate_discord_link=[boolean]`
+  None
 - **Body**
   None
 - **Headers**  
@@ -131,7 +131,7 @@ This will update a particular application, this API will only be accessible to s
 - **Params**  
   _Required:_ `userId=[string]`
 - **Query** 
-  None
+  _optional:_ `generate_discord_link=[boolean]`
 - **Body**
   None
 - **Headers**  

--- a/applications/README.md
+++ b/applications/README.md
@@ -35,9 +35,9 @@
 |                         Route                          |             Description              |
 | :----------------------------------------------------: | :----------------------------------: |
 |                [GET /applications](#get-applications)                |   Returns all the applications in the system   |
-|           [GET /applications/:userId](#get-applicationsuserid)            | Returns the logged in user's details |
-|  [POST /applications](#post-applications)   |    Returns user with given userId    |
-|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Returns user with given username   |
+|           [GET /applications/:userId](#get-applicationsuserid)            | Retruns application of a particular user |
+|  [POST /applications](#post-applications)   |    Add application of a user    |
+|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Updates application of a user   |
 |        |
 
 ## **GET /applications/**

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,0 +1,153 @@
+# application
+
+## application object
+
+```{
+  userId: string,
+  biodata: {
+    firstName: string,
+    lastName: string,
+  },
+  location: {
+    city: string,
+    state: string,
+    country: string,
+  },
+  professional: {
+    institution: string,
+    skills: string,
+  },
+  intro: {
+    introduction: string,
+    funFact: string,
+    forFun: string,
+    whyRds: string,
+    numberOfHours: string,
+  },
+  foundFrom: string,
+  status: string
+}
+```
+
+## **Requests**
+
+|                         Route                          |             Description              |
+| :----------------------------------------------------: | :----------------------------------: |
+|                [GET /applications](#get-applications)                |   Returns all the applications in the system   |
+|           [GET /applications/:userId](#get-applicationsuserid)            | Returns the logged in user's details |
+|  [POST /applications](#post-applications)   |    Returns user with given userId    |
+|       [PATCH /applications/:userId](#patch-applicationsuserid)       |   Returns user with given username   |
+|        |
+
+## **GET /applications/**
+
+Return all the applications which are not accepted or rejected, this API will only be accessible to super_user
+
+- **Params**  
+  None
+- **Query** 
+  None
+- **Body**  
+  None
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 200
+    - **Content:**
+    `{ 'message': 'applications returned successfully!', 'applications': <application_object> }`
+- **Error Response:**
+  - **Code:** 401
+    - **Content:**
+      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+  - **Code:** 500
+    - **Content:**
+      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+
+## **POST /applications/**
+
+Adds an application for joining RDS, a user can only add one application, until the previous application is either rejected or accepted by super_user
+
+- **Params**  
+  None
+- **Query** 
+  None
+- **Body** `{ <application_object> }`
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 201
+    - **Content:**
+    `{ 'message': 'application added successfully!', 'application': <application_object> }`
+- **Error Response:**
+  - **Code:** 401
+    - **Content:**
+      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+  - **Code:** 409
+    - **Content:**
+      `{ 'statusCode': 409, 'error': 'Conflict', 'message': 'User application is already present' }`
+  - **Code:** 500
+    - **Content:**
+      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+
+
+## **GET /applications/:userId**
+
+Return the application of a particular user, the super can access the application of any user, but any other can only access their application
+
+- **Params**  
+  _Required:_ `userId=[string]`
+- **Query** 
+  None
+- **Body**
+  None
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 200
+    - **Content:**
+    `{ 'message': 'User application returned successfully!', 'application': <application_object> }`
+- **Error Response:**
+  - **Code:** 401
+    - **Content:**
+      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+  - **Code:** 404
+    - **Content:**
+      `{ 'statusCode': 404, 'error': 'Not Found', 'message': 'Application doesn't exist' }`
+  - **Code:** 500
+    - **Content:**
+      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`
+
+## **PATCH /applications/:userId**
+
+This will update a particular application, this API will only be accessible to super_user
+
+- **Params**  
+  _Required:_ `userId=[string]`
+- **Query** 
+  None
+- **Body**
+  None
+- **Headers**  
+  Content-Type: application/json
+- **Cookie**  
+  rds-session: `<JWT>`
+- **Success Response:**
+  - **Code:** 204
+    - **Content:**
+    `{ 'message': 'Application updated successfully!' }`
+- **Error Response:**
+  - **Code:** 401
+    - **Content:**
+      `{ 'statusCode': 401, 'error': 'Unauthorized', 'message': 'Unauthenticated User' }`
+  - **Code:** 404
+    - **Content:**
+      `{ 'statusCode': 404, 'error': 'Not Found', 'message': 'Application doesn't exist' }`
+  - **Code:** 500
+    - **Content:**
+      `{ 'statusCode': 500, 'error': 'Internal Server Error', 'message': 'An internal server error occurred' }`


### PR DESCRIPTION
## API contract for applications
- Applications are created once the user fills out a form for joining RDS
- We currently have two APIs for adding and getting applications: `/users/self/intro` and `/users/:userId/intro`
  - `users/self/intro`: it's a patch request and it creates an application for joining RDS
  - `users/:userId/intro`: it is a get request which returns the intro of the user to the super user only
- But the issue with the above endpoints is that it has nothing to do with the user object, it updates the applicants collection, so the resource that is getting updated is applicants

- We also need a few more functionalities for the join section:
  - The superuser should be able to accept or reject an applications
  - On accepting the application a discord link should be generated and added to the application object
  - On rejecting the application the super_user will add a reason for rejection, which will be added to the application object
  - The user should be able to check if their application is accepted or rejected and join the discord group if the application is accepted and  see the reason for the rejection if the application is rejected
 
 So we will have the following endpoints:
 
 `GET: /applications`: returns all the applications which are not accepted or rejected, and if userId is passed in the query param it return a application of a particular user
 `POST: /applications`: adds the application of a user to join RDS
 `PATCH: /applications/:applicationId`: updates a particular application, this will only be accessible to super_user,
 