### PR TITLE
Added: API endpoint for archive detail logs in /logs

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -68,3 +68,97 @@ Returns all logs according to the provided queries and path/named-route param.
       "message": "Something went wrong. Please contact admin"
     }
     ```
+## **GET /logs/archivedUsers**
+
+**Note :**
+
+- This API can only be accessed by super user
+
+Returns all logs of archive user
+
+- **Param**  
+  None
+- **Query**  
+  None
+- **Body**  
+  None
+- **Headers**  
+  None
+- **Cookie**  
+  rds-session: `<JWT>`
+  
+  **Success Response:**
+  - **Code:** 200
+    - **Content:**
+    ```json
+    {
+      "message": "Logs returned successfully!",
+      "logs": ["<LOG_OBJECT>", "<LOG_OBJECT>...."]
+    }
+    ```
+- **Error Responses:**
+  - **Code:** 401
+    - **Content:**
+    ```json
+    {
+      "statusCode": 401,
+      "error": "Unauthorized",
+      "message": "Unauthenticated User"
+    }
+    ```
+  - **Code:** 500
+    - **Content:**
+    ```json
+    {
+      "statusCode": 500,
+      "error": "Internal Server Error",
+      "message": "Something went wrong. Please contact admin"
+    }
+    ```
+    ## **GET /logs/archivedUsers**
+
+**Note :**
+
+- This API can only be accessed by super user
+
+ This API will fetch the logs of specific archive details based on the query username
+
+- **Param**  
+  None
+- **Query**  
+  username=<USERNAME>
+- **Body**  
+  None
+- **Headers**  
+  None
+- **Cookie**  
+  rds-session: `<JWT>`
+  
+  **Success Response:**
+  - **Code:** 200
+    - **Content:**
+    ```json
+    {
+      "message": "Logs returned successfully!",
+      "logs": ["<LOG_OBJECT>", "<LOG_OBJECT>...."]
+    }
+    ```
+- **Error Responses:**
+  - **Code:** 401
+    - **Content:**
+    ```json
+    {
+      "statusCode": 401,
+      "error": "Unauthorized",
+      "message": "Unauthenticated User"
+    }
+    ```
+  - **Code:** 500
+    - **Content:**
+    ```json
+    {
+      "statusCode": 500,
+      "error": "Internal Server Error",
+      "message": "Something went wrong. Please contact admin"
+    }
+    ```


### PR DESCRIPTION
This PR is linked to the issue https://github.com/Real-Dev-Squad/website-backend/issues/1214

**Added endpoints**
- GET `/logs/archivedUsers` - This endpoint will fetch all the logs of archive details
- GET `/logs/archivedUsers?username=test` - This endpoint will fetch the logs of specific archive details based on the query username