### PR TITLE
Added assignee, title details to GET /tasks

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -76,6 +76,8 @@ Returns all the tasks
 - **Query**  
   - Optional: `dev=[boolean]` (`dev` is passed to get all tasks in the developer mode with features that are flagged)
   - Optional: `status=[string]` (`status` is a case insenstive string with one of the following values [AVAILABLE, ASSIGNED, COMPLETED, IN_PROGRESS, BLOCKED, SMOKE_TESTING, NEEDS_REVIEW, IN_REVIEW, APPROVED, MERGED, SANITY_CHECK, REGRESSION_CHECK, RELEASED, VERIFIED, DONE, UNASSIGNED] which represents the status of the task)
+  - Optional: `assignee=[string]` (`assignee` can be assignee username in case of single assignee or multiple comma separated values in case of multiple assignee)
+  - Optional: `title=[string]` (`title` can be case sensitive, whole or starting portion of task title)
   - Optional: `page=[integer]` (`page` can either be 0 or a positive integer. Default value is 0)
   - Optional: `size=[integer]` (`size` is the number of tasks requested per page. Range of value is 1-100. Default value is 5)
   - Optional: `next=[string]` (`next` is id of the document to get next page of results from that document)


### PR DESCRIPTION
Date: 26th Nov 2023

Developer Name: @ajoykumardas12 

----

## Issue Ticket Number
- closes #169 

## Description

`assignee` and `title` queries were missing in queries details for `GET /tasks` request. Have added those query details.

Provide a concise description of the changes made in this PR.

**Documentation Updated?**

-   [x] Yes
-   [ ] No

